### PR TITLE
Add gpu

### DIFF
--- a/lil_aretomo/aretomo.py
+++ b/lil_aretomo/aretomo.py
@@ -2,12 +2,13 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 from rich.console import Console
 
-from utils import (
+from .utils import (
     prepare_alignment_directory,
     align_tilt_series_aretomo,
     find_binning_factor,
     check_aretomo_availability,
     thickness_ang2pix,
+    convert_gpu_string,
 )
 
 console = Console(record=True)
@@ -47,7 +48,7 @@ def run_aretomo_alignment(
     See AreTomo manual for full explanation: this sets -AlignZ. Default is 1500.
     (optional) correct_tilt_angle_offset: Apply tilt angle offset correction, yes or no.
     Default is no. See AreTomo manual for full explanation: yes; adds the -TiltCor 1 argument
-    (optional) gpu_id: If you wish to run in parallel over multiple GPUs, enter GPU IDs with spaces in between. e.g. 0 1 2 3
+    (optional) gpu_id: If you wish to run in parallel over multiple GPUs, enter GPU IDs colon separated. e.g. 0:1:2
     """
     if check_aretomo_availability() is False:
         e = 'AreTomo is not available for use. Load AreTomo so it can be called from the terminal via: AreTomo.'
@@ -69,7 +70,12 @@ def run_aretomo_alignment(
         pixel_size=pixel_size,
         thickness_for_alignment=thickness_for_alignment
     )
-        	
+    
+    if gpu_id is not None:
+        gpu_id=simplify_gpu_string(
+            gpu_id
+        ) 
+
     align_tilt_series_aretomo(
         tilt_series_file=tilt_series_file,
         output_directory=output_directory,

--- a/lil_aretomo/aretomo.py
+++ b/lil_aretomo/aretomo.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 from rich.console import Console
 
-from .utils import (
+from utils import (
     prepare_alignment_directory,
     align_tilt_series_aretomo,
     find_binning_factor,

--- a/lil_aretomo/aretomo.py
+++ b/lil_aretomo/aretomo.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Tuple, List
+from typing import List, Optional, Tuple
 from rich.console import Console
 
 from .utils import (

--- a/lil_aretomo/aretomo.py
+++ b/lil_aretomo/aretomo.py
@@ -23,7 +23,8 @@ def run_aretomo_alignment(
         nominal_rotation_angle: Optional[float] = None,
         n_patches_xy: Optional[Tuple[int, int]] = (5, 4),
         thickness_for_alignment: Optional[float] = 1500,
-        correct_tilt_angle_offset: Optional[bool] = False	
+        correct_tilt_angle_offset: Optional[bool] = False,
+        gpu_id: Optional[str] = None	
 ):
     """Run aretomo alignment on a single tilt-series
     
@@ -35,7 +36,7 @@ def run_aretomo_alignment(
     pixel_size: pixel size of the tilt-series in angstroms-per-pixel
     output_directory: tilt-series directory.
     (optional) aretomo_executable: path to the AreTomo executable file
-    (optional) local_align: carry out local tilt series alignments? Yes or no, default is no
+    (optional) local_align: carry out local tilt series alignments? Yes or no, default is no. 
     (optional) target_pixel_size: the ideal pixel size at which TSA is carried out. Default is 10A
     (optional) nominal_rotation_angle: initial estimate for the rotation angle of the tilt
     axis. AreTomo does not need this information but it might help.
@@ -46,6 +47,7 @@ def run_aretomo_alignment(
     See AreTomo manual for full explanation: this sets -AlignZ. Default is 1500.
     (optional) correct_tilt_angle_offset: Apply tilt angle offset correction, yes or no.
     Default is no. See AreTomo manual for full explanation: yes; adds the -TiltCor 1 argument
+    (optional) gpu_id: If you wish to run in parallel over multiple GPUs, enter GPU IDs with spaces in between. e.g. 0 1 2 3
     """
     if check_aretomo_availability() is False:
         e = 'AreTomo is not available for use. Load AreTomo so it can be called from the terminal via: AreTomo.'
@@ -77,5 +79,6 @@ def run_aretomo_alignment(
         local_alignments=local_align,
         n_patches_xy=n_patches_xy,
         thickness_for_alignment=thickness_for_alignment,
-        correct_tilt_angle_offset=correct_tilt_angle_offset
+        correct_tilt_angle_offset=correct_tilt_angle_offset,
+        gpu_id=gpu_id
     )

--- a/lil_aretomo/aretomo.py
+++ b/lil_aretomo/aretomo.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, List
 from rich.console import Console
 
 from .utils import (
@@ -8,7 +8,6 @@ from .utils import (
     find_binning_factor,
     check_aretomo_availability,
     thickness_ang2pix,
-    convert_gpu_string,
 )
 
 console = Console(record=True)
@@ -25,7 +24,7 @@ def run_aretomo_alignment(
         n_patches_xy: Optional[Tuple[int, int]] = (5, 4),
         thickness_for_alignment: Optional[float] = 1500,
         correct_tilt_angle_offset: Optional[bool] = False,
-        gpu_id: Optional[str] = None	
+        gpu_ids: Optional[Tuple[int,...]] = None	
 ):
     """Run aretomo alignment on a single tilt-series
     
@@ -48,7 +47,7 @@ def run_aretomo_alignment(
     See AreTomo manual for full explanation: this sets -AlignZ. Default is 1500.
     (optional) correct_tilt_angle_offset: Apply tilt angle offset correction, yes or no.
     Default is no. See AreTomo manual for full explanation: yes; adds the -TiltCor 1 argument
-    (optional) gpu_id: If you wish to run in parallel over multiple GPUs, enter GPU IDs colon separated. e.g. 0:1:2
+    (optional) gpu_ids: If you wish to run in parallel over multiple GPUs, enter GPU IDs as tuple e.g. 0 1 2 3
     """
     if check_aretomo_availability() is False:
         e = 'AreTomo is not available for use. Load AreTomo so it can be called from the terminal via: AreTomo.'
@@ -70,11 +69,6 @@ def run_aretomo_alignment(
         pixel_size=pixel_size,
         thickness_for_alignment=thickness_for_alignment
     )
-    
-    if gpu_id is not None:
-        gpu_id=simplify_gpu_string(
-            gpu_id
-        ) 
 
     align_tilt_series_aretomo(
         tilt_series_file=tilt_series_file,
@@ -86,5 +80,5 @@ def run_aretomo_alignment(
         n_patches_xy=n_patches_xy,
         thickness_for_alignment=thickness_for_alignment,
         correct_tilt_angle_offset=correct_tilt_angle_offset,
-        gpu_id=gpu_id
+        gpu_ids=gpu_ids
     )

--- a/lil_aretomo/utils.py
+++ b/lil_aretomo/utils.py
@@ -6,7 +6,6 @@ from typing import List, Tuple
 
 import numpy as np
 
-
 def prepare_alignment_directory(
         tilt_series_file: Path,
         tilt_angles: List[float],
@@ -68,7 +67,8 @@ def align_tilt_series_aretomo(
 
     if gpu_id is not None:
         command.append('-Gpu')
-        command.append(f'{gpu_id}')
+        for gpu in gpu_id:
+            command.append(f'{gpu}')
 
     subprocess.run(command)
 
@@ -108,3 +108,9 @@ def thickness_ang2pix(
     ) -> int:
     thickness_for_alignment = round(thickness_for_alignment / pixel_size)
     return thickness_for_alignment
+
+def simplify_gpu_string(
+        gpu_id: str
+    ) -> str:
+    """Convert GPU  ID input from colon spaced (1:2:3) to no space inbetween GPU IDs (123)"""
+    return gpu_id.replace(':','')

--- a/lil_aretomo/utils.py
+++ b/lil_aretomo/utils.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import List, Tuple, List
+from typing import List, Tuple
 
 import numpy as np
 

--- a/lil_aretomo/utils.py
+++ b/lil_aretomo/utils.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, List
 
 import numpy as np
 
@@ -34,7 +34,7 @@ def align_tilt_series_aretomo(
         n_patches_xy: Tuple[int, int],
         thickness_for_alignment: int,
         correct_tilt_angle_offset: bool,
-        gpu_id: None or str
+        gpu_ids: None or Tuple[int,...]
 ):
     output_file_name = Path(
         f'{output_directory}/{tilt_series_file.stem}_aln{tilt_series_file.suffix}')
@@ -65,9 +65,9 @@ def align_tilt_series_aretomo(
         command.append('-TiltCor')
         command.append('1')
 
-    if gpu_id is not None:
+    if gpu_ids is not None:
         command.append('-Gpu')
-        for gpu in gpu_id:
+        for gpu in gpu_ids:
             command.append(f'{gpu}')
 
     subprocess.run(command)
@@ -108,9 +108,3 @@ def thickness_ang2pix(
     ) -> int:
     thickness_for_alignment = round(thickness_for_alignment / pixel_size)
     return thickness_for_alignment
-
-def simplify_gpu_string(
-        gpu_id: str
-    ) -> str:
-    """Convert GPU  ID input from colon spaced (1:2:3) to no space inbetween GPU IDs (123)"""
-    return gpu_id.replace(':','')

--- a/lil_aretomo/utils.py
+++ b/lil_aretomo/utils.py
@@ -34,7 +34,8 @@ def align_tilt_series_aretomo(
         local_alignments: bool,
         n_patches_xy: Tuple[int, int],
         thickness_for_alignment: int,
-        correct_tilt_angle_offset: bool
+        correct_tilt_angle_offset: bool,
+        gpu_id: None or str
 ):
     output_file_name = Path(
         f'{output_directory}/{tilt_series_file.stem}_aln{tilt_series_file.suffix}')
@@ -64,6 +65,10 @@ def align_tilt_series_aretomo(
     if correct_tilt_angle_offset:
         command.append('-TiltCor')
         command.append('1')
+
+    if gpu_id is not None:
+        command.append('-Gpu')
+        command.append(f'{gpu_id}')
 
     subprocess.run(command)
 


### PR DESCRIPTION
Allows user to specify GPU in the exact same manner as MotionCor2 in rln e.g. user provides a string with colon separated GPU IDs: 0:1:2:3