### PR TITLE
drop support for python <=3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Natural Language :: English
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -27,7 +26,7 @@ install_requires =
     numpy
     typer
     rich
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 setup_requires =
     setuptools-scm


### PR DESCRIPTION
https://numpy.org/neps/nep-0029-deprecation_policy.html