### PR TITLE
Fix writing mrc file bug

### DIFF
--- a/lil_aretomo/utils.py
+++ b/lil_aretomo/utils.py
@@ -19,7 +19,7 @@ def prepare_output_directory(
     directory.mkdir(exist_ok=True, parents=True)
 
     tilt_series_file = directory / f'{basename}.mrc'
-    data_on_disk_shape = []
+    data_on_disk_shape = None
     if tilt_series_file.exists():
         with mrcfile.open(tilt_series_file, header_only=True) as mrc:
             data_on_disk_shape = (mrc.header.nz, mrc.header.ny, mrc.header.nx)

--- a/lil_aretomo/utils.py
+++ b/lil_aretomo/utils.py
@@ -23,7 +23,7 @@ def prepare_output_directory(
     if tilt_series_file.exists():
         with mrcfile.open(tilt_series_file, header_only=True) as mrc:
             data_on_disk_shape = (mrc.header.nz, mrc.header.ny, mrc.header.nx)
-    if not np.array_equal(tilt_series.shape, data_on_disk_shape) or not tilt_series_file.exists():
+    if not np.array_equal(tilt_series.shape, data_on_disk_shape):
         mrcfile.write(
             tilt_series_file,
             tilt_series.astype(np.float32),

--- a/lil_aretomo/utils.py
+++ b/lil_aretomo/utils.py
@@ -19,10 +19,11 @@ def prepare_output_directory(
     directory.mkdir(exist_ok=True, parents=True)
 
     tilt_series_file = directory / f'{basename}.mrc'
+    data_on_disk_shape = []
     if tilt_series_file.exists():
         with mrcfile.open(tilt_series_file, header_only=True) as mrc:
             data_on_disk_shape = (mrc.header.nz, mrc.header.ny, mrc.header.nx)
-    if not np.array_equal(tilt_series.shape, data_on_disk_shape):
+    if not np.array_equal(tilt_series.shape, data_on_disk_shape) or not tilt_series_file.exists():
         mrcfile.write(
             tilt_series_file,
             tilt_series.astype(np.float32),


### PR DESCRIPTION
Added in blank list otherwise data_on_disk_shape variable doesn't exist if the mrc file doesn't already exist which led to it failing on the first run. All good?